### PR TITLE
promisify request for co v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,28 +20,34 @@ node --harmony simple.js
 Simple example:
 
 ```js
-var co = require('co')
-  , request = require('co-request');
+"use strict";
+
+let co = require("co");
+let request = require("co-request");
 
 co(function* () {
   // You can also pass options object, see http://github.com/mikeal/request docs
-  var result = yield request('http://google.com'); 
-  var response = result;
-  var body = result.body;
+    let result = yield request("http://google.com"); 
+    let response = result;
+    let body = result.body;
 
-  console.log('Response: ', response);
-  console.log('Body: ', body);
-})();
+    console.log("Response: ", response);
+    console.log("Body: ", body);
+}).catch(function (err) {
+    console.err(err);
+});
 ```
 
 POST example:
 
 ```js
+"use strict";
+
 co(function* () {
-  var result = yield request({
-  	uri: 'http://google.com',
-  	method: 'POST'
-  });
+    let result = yield request({
+        uri: "http://google.com",
+        method: "POST"
+    });
 })();
 ```
 

--- a/examples/methods.js
+++ b/examples/methods.js
@@ -1,19 +1,23 @@
 //Shows thunked methods in acion (se moore at https://github.com/mikeal/request/blob/master/README.md)
 
-var co = require('co')
-  , request = require('../');
+"use strict";
+
+let co = require('co');
+let request = require('../');
 
 co(function* () {
   //Get method
-  var getResponse = yield request.get('http://nodejs.org');
-  var body = getResponse.body;
+  let getResponse = yield request.get('http://nodejs.org');
+  let body = getResponse.body;
 
   console.log('Get Response: ', getResponse);
   console.log('Get Body: ', body);
-  
+
   //Post method
-  var postResponse = yield request.post('http://nodejs.org');
-  
+  let postResponse = yield request.post('http://nodejs.org');
+
   console.log('Post Response: ', postResponse);
 
-})();
+}).catch(function (err) {
+    console.err(err);
+});

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,12 +1,16 @@
 //Shows entire HTTP response and its body
 
-var co = require('co')
-  , request = require('../');
+"use strict";
+
+let co = require('co');
+let request = require('../');
 
 co(function* () {
-  var response = yield request('http://google.com');
-  var body = response.body;
+    let response = yield request('http://google.com');
+    let body = response.body;
 
-  console.log('Response: ', response);
-  console.log('Body: ', body);
-})();
+    console.log('Response: ', response);
+    console.log('Body: ', body);
+}).catch(function (err) {
+    console.err(err);
+});

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ let promisifyRequestMethod = function (fn) {
             // Concatenate the callback manually to avoid array arguments from co.
             return fn.apply(context, args.concat(function (err) {
                 if (err) {
-                    console.log(err);
                     reject(err);
                 } else {
                     resolve.apply(this, __slice.call(arguments, 1));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "co-request",
-  "description": "co-request thunkify wrapper for request",
+  "description": "co-request promisify wrapper for request",
   "main": "./",
   "author": {
     "name": "Dennis Leukhin",
@@ -12,7 +12,6 @@
     "test": "node_modules/.bin/mocha --harmony test/test.js"
   },
   "keywords": [
-    "thunks",
     "request",
     "rest",
     "koa",


### PR DESCRIPTION
co v4 has been released, which now relies on promises. Thunk support only remains for backwards compatibility and may be removed in future versions of co.
So I rewrite co-request in promise style. :)